### PR TITLE
updated path to hendrycks_test set on hf

### DIFF
--- a/lm_eval/tasks/hendrycks_test.py
+++ b/lm_eval/tasks/hendrycks_test.py
@@ -104,7 +104,7 @@ def create_task(subject):
 
 class GeneralHendrycksTest(MultipleChoiceTask):
     VERSION = 0
-    DATASET_PATH = "hendrycks_test"
+    DATASET_PATH = "cais/mmlu"
     DATASET_NAME = None
 
     def __init__(self, subject):


### PR DESCRIPTION
Fixed bug - 'hendrycks_test' not available on hf any more - swapped to 'cais/mmlu'