### PR TITLE
Add wandb entity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ env
 data/
 lm_cache
 .idea
+build/
+*.egg-info/

--- a/lm_eval/config.py
+++ b/lm_eval/config.py
@@ -29,3 +29,4 @@ class EvalPipelineConfig(BaseModel):
     wandb_project: str = None
     wandb_group: str = None,
     wandb_run_name: str = None
+    wandb_entity: str = "chemnlp"

--- a/main_eval.py
+++ b/main_eval.py
@@ -32,6 +32,7 @@ def main(config_path: str) -> None:
             project=args.wandb_project, 
             name=args.wandb_run_name, 
             group=args.wandb_group,
+            entity=args.wandb_entity,
             config=args,
         )
 


### PR DESCRIPTION
When running experiments the default WandB entity is not set to the shared `chemnlp`. This caused a few of my runs to be logged to my personal account. I think I could fix this for myself with some terminal commands but it's probably better to make it explicit. 